### PR TITLE
Change my to local.

### DIFF
--- a/t/ree-pcre/s.t
+++ b/t/ree-pcre/s.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More tests => 10;
 use re::engine::RE2;
 
-my $_;
+local $_;
 
 $_ = "ab";
 s/a//;


### PR DESCRIPTION
Lexical $_ has been removed ([Perl 5.24](http://perldoc.perl.org/perldelta.html#Lexical-%24_-has-been-removed)). I think it's been issuing warnings since Perl 5.18.

I think we can get away with simply deleting this line, but making it local is fine too.
