### PR TITLE
Make «no re::engine::RE2» check work on modern perls

### DIFF
--- a/t/01.basic.t
+++ b/t/01.basic.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 6;
+use Test::More tests => 7;
 use re::engine::RE2;
 
 ok("Hello, world" !~ /Goodbye, world/);
@@ -8,8 +8,9 @@ is($1, undef);
 ok("Hello, world" =~ /Hello, (world)/);
 is($1, 'world');
 
+ok(!eval '"Hello, world" =~ /(?{ }), (world)/');
 no re::engine::RE2;
-is(eval '"Hello, world" =~ /(?<=Moose|Mo), (world)/', undef);
+ok( eval '"Hello, world" =~ /(?{ }), (world)/');
 
 if (fork) {
     ok(1);


### PR DESCRIPTION
Since 5.28, perl supports variable length lookbehind, thus making the `no re::engine::RE2;` test fail. This uses the embedded code feature to make that distinction instead.