### PR TITLE
set UTF8 match flag to compute utf8 captures correctly and fix core dump

### DIFF
--- a/re2_xs.cc
+++ b/re2_xs.cc
@@ -135,7 +135,7 @@ RE2_comp(pTHX_ SV * const pattern, const U32 flags)
     RE2 * ri = NULL;
 
     if (!perl_only) {
-        ri = new RE2 (exp, options);
+        ri = new RE2 (re2::StringPiece(SvPVX(wrapped), SvCUR(wrapped)), options);
     }
 
     if (perl_only || ri->error_code()) {


### PR DESCRIPTION
RXf_MATCH_UTF8 flag is required so that the matches ($1, $2...) seen by perl are computed correctly. Without this, the current code will have strings with wrong starting offset