### PR TITLE
Fix re->nparens signess

### DIFF
--- a/re2_xs.cc
+++ b/re2_xs.cc
@@ -255,7 +255,7 @@ RE2_exec(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
     re->subbeg = strbeg;
     re->sublen = strend - strbeg;
 
-    for (int i = 0; i <= re->nparens; i++) {
+    for (U32 i = 0; i <= re->nparens; i++) {
         if(res[i].data()) {
             re->offs[i].start = res[i].data() - strbeg;
             re->offs[i].end   = res[i].data() - strbeg + res[i].length();


### PR DESCRIPTION
Comparing between signed and unsigned variables of the same size is undefined and GCC 13 warns on it:

re2_xs.cc:258:23: warning: comparison of integer expressions of different signedness: 'int' and 'U32' {aka 'unsigned int'} [-Wsign-compare]
  258 |     for (int i = 0; i <= re->nparens; i++) {
      |                     ~~^~~~~~~~~~~~~~

This patch fixes it.